### PR TITLE
FESI1-38: 모임 찜 등록 및 취소 기능

### DIFF
--- a/src/app/gathering/[id]/page.tsx
+++ b/src/app/gathering/[id]/page.tsx
@@ -1,6 +1,10 @@
-export default function GatheringDetail() {
+export default function GatheringDetail({ params }: any) {
+  const { id } = params;
+
   return (
     <div>
+      {/* TEST: id 값을 정상적으로 로드 */}
+      <h1 className="mt-36">Gathering ID: {id}</h1>
       <p>오정협 - 모임 상세페이지</p>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,18 +25,7 @@ export default function Gathering() {
 
         <section className="mx-auto grid h-full w-full grid-cols-1 gap-3 text-white xl:grid-cols-2">
           {mockGatherings.map((gathering: any) => (
-            <GatheringCard
-              registrationEnd={gathering.registrationEnd}
-              key={gathering.gatheringId}
-              location={gathering.location}
-              dateTime={gathering.dateTime}
-              level={gathering.level.toString()}
-              capacity={gathering.capacity}
-              name={gathering.name}
-              themeName={gathering.themeName}
-              image={gathering.image}
-              participantCount={gathering.participantCount.toString()}
-            />
+            <GatheringCard key={gathering.gatheringId} {...gathering} />
           ))}
         </section>
         <CreateGatheringBtn />

--- a/src/components/gathering/GatheringBadge.tsx
+++ b/src/components/gathering/GatheringBadge.tsx
@@ -1,14 +1,7 @@
+import Image from 'next/image';
 import clsx from 'clsx';
 
-import Image from 'next/image';
-
-interface BadgeProps {
-  icon?: '고급' | '중급' | '초급';
-  shape?: 'default' | 'round';
-  variant?: 'primary' | 'secondary' | 'tertiary';
-  className?: string;
-  children: React.ReactNode;
-}
+import { GatheringProps } from '@/types/gathering.types';
 
 const levelIcons = {
   고급: { src: '/icons/level_low.svg', alt: '고급 난이도 아이콘' },
@@ -23,7 +16,7 @@ export default function GatheringBadge({
   className,
   children,
   ...props
-}: BadgeProps) {
+}: GatheringProps['badge']) {
   const BadgeClass = clsx(
     'm-0 flex h-[17px]  items-center  px-2 text-center text-[10px] md:h-6 md:text-xs',
     {

--- a/src/components/gathering/GatheringCard.tsx
+++ b/src/components/gathering/GatheringCard.tsx
@@ -3,22 +3,11 @@ import Image from 'next/image';
 import UserIcon from '@/public/icons/user.svg';
 import { formatDate, extractHour } from '@/utils/dateUtils';
 import ProgressBar from '@/components/@shared/ProgressBar';
+import { GatheringProps } from '@/types/gathering.types';
+
 import AlarmBadge from './AlarmBadge';
 import GatheringBadge from './GatheringBadge';
 import HeartButton from './HeartButton';
-
-interface GatheringCardProps {
-  gatheringId: number;
-  location: string;
-  dateTime: string;
-  registrationEnd: string;
-  level: string;
-  name: string;
-  themeName: string;
-  capacity: string;
-  participantCount: string;
-  image: string;
-}
 
 export default function GatheringCard({
   gatheringId,
@@ -31,7 +20,7 @@ export default function GatheringCard({
   capacity,
   participantCount,
   image,
-}: GatheringCardProps) {
+}: GatheringProps['card']) {
   return (
     <figure className="relative flex max-h-32 w-full rounded-xl bg-brand-tertiary md:max-h-[170px]">
       <AlarmBadge hour={extractHour(registrationEnd)} />

--- a/src/components/gathering/GatheringCard.tsx
+++ b/src/components/gathering/GatheringCard.tsx
@@ -2,13 +2,13 @@ import Image from 'next/image';
 
 import UserIcon from '@/public/icons/user.svg';
 import { formatDate, extractHour } from '@/utils/dateUtils';
-
 import ProgressBar from '@/components/@shared/ProgressBar';
 import AlarmBadge from './AlarmBadge';
 import GatheringBadge from './GatheringBadge';
 import HeartButton from './HeartButton';
 
 interface GatheringCardProps {
+  gatheringId: number;
   location: string;
   dateTime: string;
   registrationEnd: string;
@@ -21,6 +21,7 @@ interface GatheringCardProps {
 }
 
 export default function GatheringCard({
+  gatheringId,
   location,
   dateTime,
   registrationEnd,
@@ -57,7 +58,20 @@ export default function GatheringCard({
               {formatDate(dateTime)}
             </GatheringBadge>
           </div>
-          <HeartButton />
+          <HeartButton
+            gathering={{
+              gatheringId,
+              location,
+              dateTime,
+              registrationEnd,
+              level,
+              name,
+              themeName,
+              capacity,
+              participantCount,
+              image,
+            }}
+          />
         </div>
         <div>
           <p className="text-sm font-semibold md:text-lg">{name}</p>

--- a/src/components/gathering/GatheringCard.tsx
+++ b/src/components/gathering/GatheringCard.tsx
@@ -23,68 +23,70 @@ export default function GatheringCard({
   image,
 }: GatheringProps['card']) {
   return (
-    <Link href={`/gathering/${gatheringId}`}>
-      <figure className="relative flex max-h-32 w-full rounded-xl bg-brand-tertiary md:max-h-[170px]">
-        <AlarmBadge hour={extractHour(registrationEnd)} />
-        <Image
-          src={image}
-          alt="방탈출 테마 이미지"
-          width={240}
-          height={170}
-          quality={100}
-          className="w-28 rounded-l-xl bg-brand-secondary md:w-60"
-        />
-        <div className="mx-3 my-2 flex flex-1 flex-col justify-between md:mx-6 md:my-4">
-          <div className="flex justify-between">
-            <div className="flex items-center gap-1 text-sm md:gap-[6px]">
-              <GatheringBadge
-                icon={level as '고급' | '중급' | '초급'}
-                variant="primary"
-                shape="round"
-              >
-                {level}
-              </GatheringBadge>
-              <GatheringBadge variant="secondary">{location}</GatheringBadge>
-              <GatheringBadge variant="tertiary">
-                {formatDate(dateTime)}
-              </GatheringBadge>
+    <figure className="relative">
+      <Link href={`/gathering/${gatheringId}`}>
+        <div className="flex max-h-32 w-full rounded-xl bg-brand-tertiary md:max-h-[170px]">
+          <AlarmBadge hour={extractHour(registrationEnd)} />
+          <Image
+            src={image}
+            alt="방탈출 테마 이미지"
+            width={240}
+            height={170}
+            quality={100}
+            className="w-28 rounded-l-xl bg-brand-secondary md:w-60"
+          />
+          <div className="mx-3 my-2 flex flex-1 flex-col justify-between md:mx-6 md:my-4">
+            <div className="flex justify-between">
+              <div className="flex items-center gap-1 text-sm md:gap-[6px]">
+                <GatheringBadge
+                  icon={level as '고급' | '중급' | '초급'}
+                  variant="primary"
+                  shape="round"
+                >
+                  {level}
+                </GatheringBadge>
+                <GatheringBadge variant="secondary">{location}</GatheringBadge>
+                <GatheringBadge variant="tertiary">
+                  {formatDate(dateTime)}
+                </GatheringBadge>
+              </div>
             </div>
-            <HeartButton
-              gathering={{
-                gatheringId,
-                location,
-                dateTime,
-                registrationEnd,
-                level,
-                name,
-                themeName,
-                capacity,
-                participantCount,
-                image,
-              }}
-            />
-          </div>
-          <div>
-            <p className="text-sm font-semibold md:text-lg">{name}</p>
-            <p className="text-xs font-light md:text-sm">{themeName}</p>
-          </div>
-          <div className="flex flex-col gap-1">
-            <div className="flex items-center gap-1 text-[10px] text-text-secondary md:text-sm">
-              <UserIcon />
-              <p>
-                {participantCount}/{capacity}
-              </p>
-              {participantCount !== capacity && (
-                <>
-                  <span>·</span>
-                  <p>모집중</p>
-                </>
-              )}
+            <div>
+              <p className="text-sm font-semibold md:text-lg">{name}</p>
+              <p className="text-xs font-light md:text-sm">{themeName}</p>
             </div>
-            <ProgressBar max={capacity} value={participantCount} />
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center gap-1 text-[10px] text-text-secondary md:text-sm">
+                <UserIcon />
+                <p>
+                  {participantCount}/{capacity}
+                </p>
+                {participantCount !== capacity && (
+                  <>
+                    <span>·</span>
+                    <p>모집중</p>
+                  </>
+                )}
+              </div>
+              <ProgressBar max={capacity} value={participantCount} />
+            </div>
           </div>
         </div>
-      </figure>
-    </Link>
+      </Link>
+      <HeartButton
+        gathering={{
+          gatheringId,
+          location,
+          dateTime,
+          registrationEnd,
+          level,
+          name,
+          themeName,
+          capacity,
+          participantCount,
+          image,
+        }}
+      />
+    </figure>
   );
 }

--- a/src/components/gathering/GatheringCard.tsx
+++ b/src/components/gathering/GatheringCard.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 
 import UserIcon from '@/public/icons/user.svg';
 import { formatDate, extractHour } from '@/utils/dateUtils';
@@ -22,66 +23,68 @@ export default function GatheringCard({
   image,
 }: GatheringProps['card']) {
   return (
-    <figure className="relative flex max-h-32 w-full rounded-xl bg-brand-tertiary md:max-h-[170px]">
-      <AlarmBadge hour={extractHour(registrationEnd)} />
-      <Image
-        src={image}
-        alt="방탈출 테마 이미지"
-        width={240}
-        height={170}
-        quality={100}
-        className="w-28 rounded-l-xl bg-brand-secondary md:w-60"
-      />
-      <div className="mx-3 my-2 flex flex-1 flex-col justify-between md:mx-6 md:my-4">
-        <div className="flex justify-between">
-          <div className="flex items-center gap-1 text-sm md:gap-[6px]">
-            <GatheringBadge
-              icon={level as '고급' | '중급' | '초급'}
-              variant="primary"
-              shape="round"
-            >
-              {level}
-            </GatheringBadge>
-            <GatheringBadge variant="secondary">{location}</GatheringBadge>
-            <GatheringBadge variant="tertiary">
-              {formatDate(dateTime)}
-            </GatheringBadge>
+    <Link href={`/gathering/${gatheringId}`}>
+      <figure className="relative flex max-h-32 w-full rounded-xl bg-brand-tertiary md:max-h-[170px]">
+        <AlarmBadge hour={extractHour(registrationEnd)} />
+        <Image
+          src={image}
+          alt="방탈출 테마 이미지"
+          width={240}
+          height={170}
+          quality={100}
+          className="w-28 rounded-l-xl bg-brand-secondary md:w-60"
+        />
+        <div className="mx-3 my-2 flex flex-1 flex-col justify-between md:mx-6 md:my-4">
+          <div className="flex justify-between">
+            <div className="flex items-center gap-1 text-sm md:gap-[6px]">
+              <GatheringBadge
+                icon={level as '고급' | '중급' | '초급'}
+                variant="primary"
+                shape="round"
+              >
+                {level}
+              </GatheringBadge>
+              <GatheringBadge variant="secondary">{location}</GatheringBadge>
+              <GatheringBadge variant="tertiary">
+                {formatDate(dateTime)}
+              </GatheringBadge>
+            </div>
+            <HeartButton
+              gathering={{
+                gatheringId,
+                location,
+                dateTime,
+                registrationEnd,
+                level,
+                name,
+                themeName,
+                capacity,
+                participantCount,
+                image,
+              }}
+            />
           </div>
-          <HeartButton
-            gathering={{
-              gatheringId,
-              location,
-              dateTime,
-              registrationEnd,
-              level,
-              name,
-              themeName,
-              capacity,
-              participantCount,
-              image,
-            }}
-          />
-        </div>
-        <div>
-          <p className="text-sm font-semibold md:text-lg">{name}</p>
-          <p className="text-xs font-light md:text-sm">{themeName}</p>
-        </div>
-        <div className="flex flex-col gap-1">
-          <div className="flex items-center gap-1 text-[10px] text-text-secondary md:text-sm">
-            <UserIcon />
-            <p>
-              {participantCount}/{capacity}
-            </p>
-            {participantCount !== capacity && (
-              <>
-                <span>·</span>
-                <p>모집중</p>
-              </>
-            )}
+          <div>
+            <p className="text-sm font-semibold md:text-lg">{name}</p>
+            <p className="text-xs font-light md:text-sm">{themeName}</p>
           </div>
-          <ProgressBar max={capacity} value={participantCount} />
+          <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-1 text-[10px] text-text-secondary md:text-sm">
+              <UserIcon />
+              <p>
+                {participantCount}/{capacity}
+              </p>
+              {participantCount !== capacity && (
+                <>
+                  <span>·</span>
+                  <p>모집중</p>
+                </>
+              )}
+            </div>
+            <ProgressBar max={capacity} value={participantCount} />
+          </div>
         </div>
-      </div>
-    </figure>
+      </figure>
+    </Link>
   );
 }

--- a/src/components/gathering/HeartButton.tsx
+++ b/src/components/gathering/HeartButton.tsx
@@ -24,7 +24,9 @@ export default function HeartButton({
     );
   }, [gathering]);
 
-  const handleFavoriteToggle = () => {
+  const handleFavoriteToggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+
     setIsFavorited((prev) => {
       const newFavorited = !prev;
       const favorites = JSON.parse(localStorage.getItem('favorites') || '[]');
@@ -53,8 +55,10 @@ export default function HeartButton({
   };
 
   return (
-    <button type="button" onClick={handleFavoriteToggle}>
-      {isFavorited ? <HeartFullIcon /> : <HeartEmptyIcon />}
-    </button>
+    <div className="absolute right-2 top-1 md:right-6 md:top-4 ">
+      <button type="button" onClick={handleFavoriteToggle}>
+        {isFavorited ? <HeartFullIcon /> : <HeartEmptyIcon />}
+      </button>
+    </div>
   );
 }

--- a/src/components/gathering/HeartButton.tsx
+++ b/src/components/gathering/HeartButton.tsx
@@ -1,15 +1,65 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import HeartFullIcon from '@/public/icons/heart_full.svg';
 import HeartEmptyIcon from '@/public/icons/heart_empty.svg';
 
-export default function HeartButton() {
+interface GatheringCardProps {
+  gatheringId: number;
+  location: string;
+  dateTime: string;
+  registrationEnd: string;
+  level: string;
+  name: string;
+  themeName: string;
+  capacity: string;
+  participantCount: string;
+  image: string;
+}
+
+export default function HeartButton({
+  gathering,
+}: {
+  gathering: GatheringCardProps;
+}) {
   const [isFavorited, setIsFavorited] = useState(false);
 
+  // 컴포넌트가 마운트될 때 찜 상태 불러오기
+  useEffect(() => {
+    const favorites = JSON.parse(localStorage.getItem('favorites') || '[]');
+    setIsFavorited(
+      favorites.some(
+        (fav: GatheringCardProps) => fav.gatheringId === gathering.gatheringId
+      )
+    );
+  }, [gathering]);
+
   const handleFavoriteToggle = () => {
-    setIsFavorited(!isFavorited);
+    setIsFavorited((prev) => {
+      const newFavorited = !prev;
+      const favorites = JSON.parse(localStorage.getItem('favorites') || '[]');
+
+      if (newFavorited) {
+        if (
+          !favorites.some(
+            (fav: GatheringCardProps) =>
+              fav.gatheringId === gathering.gatheringId
+          )
+        ) {
+          favorites.push(gathering);
+        }
+      } else {
+        const updatedFavorites = favorites.filter(
+          (fav: GatheringCardProps) => fav.gatheringId !== gathering.gatheringId
+        );
+        localStorage.setItem('favorites', JSON.stringify(updatedFavorites));
+        return false;
+      }
+
+      localStorage.setItem('favorites', JSON.stringify(favorites));
+      return newFavorited;
+    });
   };
 
   return (

--- a/src/components/gathering/HeartButton.tsx
+++ b/src/components/gathering/HeartButton.tsx
@@ -2,26 +2,14 @@
 
 import { useEffect, useState } from 'react';
 
+import { GatheringProps } from '@/types/gathering.types';
 import HeartFullIcon from '@/public/icons/heart_full.svg';
 import HeartEmptyIcon from '@/public/icons/heart_empty.svg';
-
-interface GatheringCardProps {
-  gatheringId: number;
-  location: string;
-  dateTime: string;
-  registrationEnd: string;
-  level: string;
-  name: string;
-  themeName: string;
-  capacity: string;
-  participantCount: string;
-  image: string;
-}
 
 export default function HeartButton({
   gathering,
 }: {
-  gathering: GatheringCardProps;
+  gathering: GatheringProps['card'];
 }) {
   const [isFavorited, setIsFavorited] = useState(false);
 
@@ -30,7 +18,8 @@ export default function HeartButton({
     const favorites = JSON.parse(localStorage.getItem('favorites') || '[]');
     setIsFavorited(
       favorites.some(
-        (fav: GatheringCardProps) => fav.gatheringId === gathering.gatheringId
+        (fav: GatheringProps['card']) =>
+          fav.gatheringId === gathering.gatheringId
       )
     );
   }, [gathering]);
@@ -43,7 +32,7 @@ export default function HeartButton({
       if (newFavorited) {
         if (
           !favorites.some(
-            (fav: GatheringCardProps) =>
+            (fav: GatheringProps['card']) =>
               fav.gatheringId === gathering.gatheringId
           )
         ) {
@@ -51,7 +40,8 @@ export default function HeartButton({
         }
       } else {
         const updatedFavorites = favorites.filter(
-          (fav: GatheringCardProps) => fav.gatheringId !== gathering.gatheringId
+          (fav: GatheringProps['card']) =>
+            fav.gatheringId !== gathering.gatheringId
         );
         localStorage.setItem('favorites', JSON.stringify(updatedFavorites));
         return false;

--- a/src/types/gathering.types.ts
+++ b/src/types/gathering.types.ts
@@ -49,3 +49,26 @@ export interface GatheringRequestBody {
     gatheringId: number;
   };
 }
+
+// Component's props
+export interface GatheringProps {
+  card: {
+    gatheringId: number;
+    location: string;
+    dateTime: string;
+    registrationEnd: string;
+    level: string;
+    name: string;
+    themeName: string;
+    capacity: string;
+    participantCount: string;
+    image: string;
+  };
+  badge: {
+    icon?: '고급' | '중급' | '초급';
+    shape?: 'default' | 'round';
+    variant?: 'primary' | 'secondary' | 'tertiary';
+    className?: string;
+    children: React.ReactNode;
+  };
+}


### PR DESCRIPTION
## ✏️ 작업 내용 요약

> 1. 모임 찜 등록 및 취소 기능
> 2. 기존의 찜 상태 불러오기
> 3. 모임 카드 클릭 시 상세 페이지로 이동
> 4. gatheringCard 컴포넌트의 props 간략화

## 💬 리뷰 요구사항

- 찜 기능을 찜한 목록 페이지와 연계해서 테스트하기 위해 `dev` 브랜치에 병합하도록 했습니다.

- 찜 버튼 클릭 시 모임 카드의 모든 props를 저장합니다.

## 🏷️ 연관된 JIRA 번호

> FESI1-38

## 📷 스크린샷

> ### 로컬 스토리지
![image](https://github.com/user-attachments/assets/6d7f4179-243f-4b3c-a3b5-694fc581c59e)

> ### 찜 등록 및 취소
> 모임 카드 클릭 시 상세 페이지로 이동합니다.

![SHANA 찜 등록 및 취소_페이지 이동](https://github.com/user-attachments/assets/fe607982-c1f3-4269-a81e-6a38afc12ff1)

