### PR TITLE
FESI1-65: 홈 페이지 디자인 수정

### DIFF
--- a/src/app/gathering/page.tsx
+++ b/src/app/gathering/page.tsx
@@ -1,5 +1,6 @@
 import { mockGatherings } from '@/data/mockGatherings';
 
+import HeaderTitle from '@/components/@shared/HeaderTitle';
 import CreateGatheringBtn from '@/components/gathering/CreateGatheringBtn';
 import GatheringList from '@/components/gathering/GatheringList';
 
@@ -7,14 +8,13 @@ export default function Gathering() {
   const gatherings = mockGatherings;
 
   return (
-    <div className="mx-auto flex h-full max-w-6xl flex-col gap-12 px-4 py-24 md:py-32 xl:px-0">
-      <header className="mx-1 flex flex-col gap-2 text-white xl:mx-5">
-        <h1 className="order-2 text-lg font-semibold md:text-2xl">
-          지금 여기로 모여방
-        </h1>
-        <p className="order-1 text-sm font-medium">함께 할 사람이 없나요?</p>
-      </header>
-      <main className="flex flex-col gap-10 md:gap-12">
+    <div className="mx-auto flex h-full max-w-[1166px] flex-col gap-12 px-4 py-24 md:px-6 md:py-32 xl:px-0">
+      <HeaderTitle
+        title="지금 여기로 모여방"
+        content="함께 할 사람이 없나요?"
+        order="inverse"
+      />
+      <main className="flex flex-col gap-10 md:gap-12 ">
         <GatheringList gatherings={gatherings} />
         <CreateGatheringBtn />
       </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,6 @@ export default function Home() {
             width={1166}
             height={288}
             quality={100}
-            layout="responsive"
             className="max-h-full max-w-full rounded-3xl"
           />
         </header>

--- a/src/components/@shared/HeaderTitle.tsx
+++ b/src/components/@shared/HeaderTitle.tsx
@@ -1,13 +1,32 @@
+import clsx from 'clsx';
+
 interface HeaderTitleProps {
   title: string;
   content: string;
+  order?: 'inverse';
 }
 
-export default function HeaderTitle({ title, content }: HeaderTitleProps) {
+export default function HeaderTitle({
+  title,
+  content,
+  order,
+}: HeaderTitleProps) {
   return (
     <header className="flex flex-col gap-2">
-      <h1 className="text-2xl font-semibold">{title}</h1>
-      <p className="text-sm font-medium">{content}</p>
+      <h1
+        className={clsx('text-2xl font-semibold', {
+          'order-2': order === 'inverse',
+        })}
+      >
+        {title}
+      </h1>
+      <p
+        className={clsx('text-sm font-medium', {
+          'order-1': order === 'inverse',
+        })}
+      >
+        {content}
+      </p>
     </header>
   );
 }

--- a/src/components/gathering/AlarmBadge.tsx
+++ b/src/components/gathering/AlarmBadge.tsx
@@ -1,21 +1,33 @@
 import Image from 'next/image';
 
+import clsx from 'clsx';
+
 interface AlarmBadgeProps {
   hour: number;
+  layout?: 'card' | 'slot';
 }
 
-export default function AlarmBadge({ hour }: AlarmBadgeProps) {
+export default function AlarmBadge({ hour, layout = 'card' }: AlarmBadgeProps) {
   return (
-    <div className="absolute left-2 top-2 flex h-[17px] items-center rounded-full bg-point-tag pl-1 pr-2 md:h-8 md:px-2">
+    <div
+      className={clsx('absolute  flex items-center rounded-full bg-point-tag', {
+        'left-2 top-2 h-[17px] pl-1 pr-2 text-[10px] md:h-8 md:px-2 md:text-xs':
+          layout === 'card',
+        'left-4 top-4 h-8 pl-2 pr-3 text-xs': layout === 'slot',
+      })}
+    >
       <Image
         src="/icons/alarm.svg"
         alt="알람 아이콘"
         width={24}
         height={24}
         quality={100}
-        className="h-[14px] w-[14px] md:h-6 md:w-6"
+        className={clsx('', {
+          'h-[14px] w-[14px] md:h-6 md:w-6': layout === 'card',
+          'h-6 w-6': layout === 'slot',
+        })}
       />
-      <span className="ml-1 text-[10px] md:text-xs">오늘 {hour}시 마감</span>
+      <span className="ml-1 ">오늘 {hour}시 마감</span>
     </div>
   );
 }

--- a/src/components/gathering/GatheringCard.tsx
+++ b/src/components/gathering/GatheringCard.tsx
@@ -68,7 +68,7 @@ export default function GatheringCard({
               </p>
             </div>
             <div className="flex flex-col gap-1">
-              <div className="text-text-secondary flex items-center gap-1 text-[10px] md:text-sm">
+              <div className="flex items-center gap-1 text-[10px] text-text-secondary md:text-sm">
                 <UserIcon />
                 <p>
                   {participantCount}/{capacity}

--- a/src/components/gathering/GatheringCard.tsx
+++ b/src/components/gathering/GatheringCard.tsx
@@ -37,7 +37,7 @@ export default function GatheringCard({
             width={240}
             height={170}
             quality={100}
-            className="w-28 rounded-l-xl bg-default-tertiary md:w-60"
+            className="w-28 rounded-l-xl bg-default-tertiary object-cover md:w-60"
           />
           <div className="mx-3 my-2 flex flex-1 flex-col justify-between md:mx-6 md:my-4">
             <div className="flex justify-between">

--- a/src/components/gathering/GatheringList.tsx
+++ b/src/components/gathering/GatheringList.tsx
@@ -66,13 +66,13 @@ export default function GatheringList({ gatherings }: GatheringListProps) {
 
   return (
     <>
-      <section className="mx-1 flex flex-col xl:mx-5">
+      <section className="flex flex-col">
         <div className="flex flex-col gap-7">
           <GenreFilter
             onGenreChange={(value) => handleFilterChange('genre', value)}
             selectedGenre={filters.genre}
           />
-          <div className="text-text-secondary flex justify-between">
+          <div className="flex justify-between text-text-secondary">
             <div className="flex justify-between">
               <div className="mr-2 flex gap-2">
                 <LocationDropdown

--- a/src/components/gathering/PuzzleButton.tsx
+++ b/src/components/gathering/PuzzleButton.tsx
@@ -2,18 +2,25 @@
 
 import { useEffect, useState } from 'react';
 import Image from 'next/image';
+import clsx from 'clsx';
 
 import { GatheringProps } from '@/types/gathering.types';
 
+interface PuzzleButtonProps {
+  layout?: 'card' | 'slot';
+  gathering: GatheringProps['card'] | undefined;
+}
+
 export default function PuzzleButton({
+  layout = 'card',
   gathering,
-}: {
-  gathering: GatheringProps['card'];
-}) {
+}: PuzzleButtonProps) {
   const [isFavorited, setIsFavorited] = useState(false);
 
   // 컴포넌트가 마운트될 때 찜 상태 불러오기
   useEffect(() => {
+    if (!gathering) return;
+
     const favorites = JSON.parse(localStorage.getItem('favorites') || '[]');
     setIsFavorited(
       favorites.some(
@@ -25,6 +32,8 @@ export default function PuzzleButton({
 
   const handleFavoriteToggle = (e: React.MouseEvent) => {
     e.stopPropagation();
+
+    if (!gathering) return;
 
     setIsFavorited((prev) => {
       const newFavorited = !prev;
@@ -52,7 +61,6 @@ export default function PuzzleButton({
       return newFavorited;
     });
   };
-
   return (
     <div className="absolute right-2 top-1 md:right-6 md:top-4 ">
       <button type="button" onClick={handleFavoriteToggle}>
@@ -64,7 +72,10 @@ export default function PuzzleButton({
           width={24}
           height={24}
           quality={100}
-          className="m-1 h-4 w-4 md:m-0 md:h-6 md:w-6"
+          className={clsx('object-contain', {
+            'm-1 h-4 w-4 md:m-0 md:h-6 md:w-6': layout === 'card',
+            'm-4 h-6 w-6 md:m-0': layout === 'slot',
+          })}
         />
       </button>
     </div>

--- a/src/components/home/GatheringSlot.tsx
+++ b/src/components/home/GatheringSlot.tsx
@@ -6,7 +6,7 @@ import { extractHour } from '@/utils/dateUtils';
 import { GatheringProps } from '@/types/gathering.types';
 
 import AlarmBadge from '@/components/gathering/AlarmBadge';
-// import PuzzleButton from '@/components/gathering/PuzzleButton';
+import PuzzleButton from '@/components/gathering/PuzzleButton';
 
 export default function GatheringSlot({
   gatheringId,
@@ -19,7 +19,7 @@ export default function GatheringSlot({
   return (
     <figure className="relative col-span-1 row-span-1 max-w-full rounded-2xl bg-black xl:max-h-[317px] xl:max-w-[358px]">
       <Link href={`/gathering/${gatheringId}`}>
-        <AlarmBadge hour={extractHour(registrationEnd)} />
+        <AlarmBadge layout="slot" hour={extractHour(registrationEnd)} />
         <Image
           src={image}
           alt="방탈출 테마 이미지"
@@ -39,6 +39,7 @@ export default function GatheringSlot({
           {name}
         </p>
       </Link>
+      <PuzzleButton layout="slot" gatheringId={gatheringId} />
     </figure>
   );
 }

--- a/src/components/home/GatheringSlot.tsx
+++ b/src/components/home/GatheringSlot.tsx
@@ -39,7 +39,21 @@ export default function GatheringSlot({
           {name}
         </p>
       </Link>
-      <PuzzleButton layout="slot" gatheringId={gatheringId} />
+      <PuzzleButton
+        layout="slot"
+        gathering={{
+          gatheringId,
+          registrationEnd,
+          name,
+          capacity,
+          participantCount,
+          image,
+          dateTime: '',
+          level: '',
+          themeName: '',
+          location: '',
+        }}
+      />
     </figure>
   );
 }

--- a/src/components/home/NearDeadlines.tsx
+++ b/src/components/home/NearDeadlines.tsx
@@ -36,7 +36,6 @@ export default function NearDeadlines({ gatherings }: GatheringListProps) {
               width={204}
               height={158}
               quality={100}
-              layout="fit"
               className="mt-auto hidden max-h-full md:block xl:hidden"
             />
           </div>
@@ -70,7 +69,6 @@ export default function NearDeadlines({ gatherings }: GatheringListProps) {
           quality={100}
           width={487}
           height={466}
-          layout="responsive"
           className="mt-auto hidden md:hidden xl:block xl:max-h-[466px] xl:max-w-[457px]"
         />
       </div>

--- a/src/components/home/NearDeadlines.tsx
+++ b/src/components/home/NearDeadlines.tsx
@@ -40,7 +40,7 @@ export default function NearDeadlines({ gatherings }: GatheringListProps) {
               className="mt-auto hidden max-h-full md:block xl:hidden"
             />
           </div>
-          <div className="grid grid-cols-1 grid-rows-1 gap-7 md:grid-cols-2">
+          <div className="grid grid-cols-1 grid-rows-1 gap-3 md:grid-cols-2 md:gap-7">
             {currentItems.map((gathering: any) => (
               <GatheringSlot
                 key={gathering.gatheringId}


### PR DESCRIPTION
## ✏️ 작업 내용 요약

> 1. 홈 페이지 디자인 수정
> 2. 모임 찾기 페이지 마진 값 통일
> 3. 모임 찾기 페이지 HeaderTitle 적용

## 💬 리뷰 요구사항 

- 찜한 모임 페이지 테스트를 위해 마감 임박 모임 섹션에서 GatheringSlot의 퍼즐 아이콘 클릭 시 GatheringSlot에 포함되지 않은 데이터는 빈 문자열로 전달하도록 했습니다.
 → api 연동 후 gatheringId만 전달하도록 수정 예정

- `useEffect`를 사용하지 않으면서 사용자에게 보여줄 모임 개수를 조절하는 방안을 고민 중입니다. 아이디어가 있다면 공유 부탁드립니다. 😢

- PageContainer는 모임 찾기 페이지에서 호환되지 않아 적용하지 않았습니다.

## 🏷️ 연관된 JIRA 번호

> FESI1-65

## 📷 스크린샷

> ### 모임 카드 이미지 비율 유지
![image](https://github.com/user-attachments/assets/1282622e-9633-4c1a-b26f-25891f9a3ccb)


> ### GatheringSlot 레이아웃 수정, 퍼즐 아이콘 추가
![image](https://github.com/user-attachments/assets/8b8907d5-e100-44d8-b1f0-bb2f7bb5a4aa)
