### PR TITLE
FESI1-62 모임상세- 모임 주최자 프로필 모달 반응형 레이아웃 구현 

### DIFF
--- a/public/icons/right.svg
+++ b/public/icons/right.svg
@@ -1,0 +1,3 @@
+<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 7L15 12L10 17" stroke="white" stroke-width="1.50331" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/app/gathering/[id]/page.tsx
+++ b/src/app/gathering/[id]/page.tsx
@@ -1,11 +1,13 @@
+/* eslint-disable prettier/prettier */
+
 'use client';
 
 import Button from '@/components/@shared/Button';
-import IconButton from '@/components/@shared/IconButton';
 import GatheringCreaterProfileModal from '@/components/gatheringDetail/GatheringCreaterProfileModal';
 import { mockGatheringCreater } from '@/data/mockGatheringCreater';
 import { useModal } from '@/hooks/useModal';
 import Image from 'next/image';
+
 export default function GatheringDetail({ params }: any) {
   const { id } = params;
   const createrProfile = mockGatheringCreater;
@@ -40,7 +42,7 @@ export default function GatheringDetail({ params }: any) {
         >
           프로필 보기
         </Button>
-        <button onClick={openModal} className="block md:hidden">
+        <button onClick={openModal} type="button" className="block md:hidden">
           <Image
             src="/icons/right.svg"
             width={24}

--- a/src/app/gathering/[id]/page.tsx
+++ b/src/app/gathering/[id]/page.tsx
@@ -1,11 +1,61 @@
+'use client';
+
+import Button from '@/components/@shared/Button';
+import IconButton from '@/components/@shared/IconButton';
+import GatheringCreaterProfileModal from '@/components/gatheringDetail/GatheringCreaterProfileModal';
+import { mockGatheringCreater } from '@/data/mockGatheringCreater';
+import { useModal } from '@/hooks/useModal';
+import Image from 'next/image';
 export default function GatheringDetail({ params }: any) {
   const { id } = params;
+  const createrProfile = mockGatheringCreater;
+  const { isOpen, openModal, closeModal } = useModal();
 
   return (
     <div>
       {/* TEST: id 값을 정상적으로 로드 */}
       <h1 className="mt-36">Gathering ID: {id}</h1>
       <p>오정협 - 모임 상세페이지</p>
+      <div className="border-default-inverse flex h-[66px] w-full items-center justify-between rounded-2xl border px-7 py-2 md:h-[90px]">
+        <div className="flex items-center gap-3">
+          <Image
+            src={createrProfile.image || '/profile_image_default.png'}
+            width={52}
+            height={52}
+            alt="모임주최자 프로필 이미지"
+          />
+          <div>
+            <p className="text-xl font-bold">{createrProfile.nickname}</p>
+            <p className="text-sm">
+              모집글 ({createrProfile.gatherings.length})
+            </p>
+          </div>
+        </div>
+        <Button
+          variant="primary"
+          fontSize="14"
+          padding="12"
+          className="hidden md:block"
+          onClick={openModal}
+        >
+          프로필 보기
+        </Button>
+        <button onClick={openModal} className="block md:hidden">
+          <Image
+            src="/icons/right.svg"
+            width={24}
+            height={24}
+            alt="모임 주최자 프로필 상세보기 버튼"
+          />
+        </button>
+      </div>
+      {isOpen && (
+        <GatheringCreaterProfileModal
+          isModal={isOpen}
+          onClose={closeModal}
+          createrProfile={createrProfile}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -78,7 +78,7 @@ export default function MyPage() {
           width={241}
           height={121}
           alt="프로필 배경"
-          className="pointer-events-none absolute left-16 top-3 -z-10 md:hidden"
+          className="pointer-events-none absolute left-12 top-2 -z-10 md:hidden"
         />
         <IconButton
           src="/icons/pencil.svg"

--- a/src/components/gatheringDetail/GatheringCreaterProfileGatheringList.tsx
+++ b/src/components/gatheringDetail/GatheringCreaterProfileGatheringList.tsx
@@ -1,8 +1,7 @@
-import { mockGatherings } from '@/data/mockGatherings';
+import { GatheringCreaterDTO } from '@/types/gathering.types';
 import MyGatheringCard from '../mypage/myGatheringCard';
 import EmptyElement from '../@shared/EmptyElement';
 import MyCreateGatheringDetail from '../mypage/myGatheringCard/myCreateGatheringDetail';
-import { GatheringCreaterDTO } from '@/types/gathering.types';
 
 interface GatheringCreaterProfileGatheringListProps {
   createrGatheringList: GatheringCreaterDTO['get']['gatherings'];

--- a/src/components/gatheringDetail/GatheringCreaterProfileGatheringList.tsx
+++ b/src/components/gatheringDetail/GatheringCreaterProfileGatheringList.tsx
@@ -1,0 +1,32 @@
+import { mockGatherings } from '@/data/mockGatherings';
+import MyGatheringCard from '../mypage/myGatheringCard';
+import EmptyElement from '../@shared/EmptyElement';
+import MyCreateGatheringDetail from '../mypage/myGatheringCard/myCreateGatheringDetail';
+import { GatheringCreaterDTO } from '@/types/gathering.types';
+
+interface GatheringCreaterProfileGatheringListProps {
+  createrGatheringList: GatheringCreaterDTO['get']['gatherings'];
+}
+export default function GatheringCreaterProfileGatheringList({
+  createrGatheringList,
+}: GatheringCreaterProfileGatheringListProps) {
+  if (!createrGatheringList || createrGatheringList.length === 0) {
+    return <EmptyElement>아직 만든 모임이 없어요</EmptyElement>;
+  }
+  return (
+    <div className="flex flex-col gap-5">
+      {createrGatheringList.map((gathering: any) => (
+        <MyGatheringCard key={gathering.gatheringId} image={gathering.image}>
+          <MyCreateGatheringDetail
+            location={gathering.location}
+            dateTime={gathering.dateTime}
+            name={gathering.name}
+            themeName={gathering.themeName}
+            capacity={gathering.capacity}
+            participantCount={gathering.participantCount}
+          />
+        </MyGatheringCard>
+      ))}
+    </div>
+  );
+}

--- a/src/components/gatheringDetail/GatheringCreaterProfileModal.tsx
+++ b/src/components/gatheringDetail/GatheringCreaterProfileModal.tsx
@@ -1,0 +1,70 @@
+import Modal from '@/components/@shared/Modal';
+import { GatheringCreaterDTO } from '@/types/gathering.types';
+import Image from 'next/image';
+import GatheringCreaterProfileGatheringList from './GatheringCreaterProfileGatheringList';
+interface GatheringCreaterProfileModalProps {
+  isModal: boolean;
+  onClose: () => void;
+  createrProfile: GatheringCreaterDTO['get'];
+}
+export default function GatheringCreaterProfileModal({
+  isModal,
+  onClose,
+  createrProfile,
+}: GatheringCreaterProfileModalProps) {
+  const levelImage = Math.min(createrProfile.gatherings.length, 6);
+
+  return (
+    <Modal
+      isOpen={isModal}
+      onClose={onClose}
+      customDimStyle="w-full bg-secondary-80 md:w-[694px] lg:w-[1281px] text-default-inverse"
+    >
+      <div className="bg-primary-30 relative z-0 mb-5 mt-8 flex items-center justify-between overflow-hidden rounded-[25px] border px-3 py-8 md:mb-7 md:px-10">
+        <div className="text-default-inverse z-10 flex flex-col gap-3">
+          <Image
+            src={createrProfile.image || '/profile_image_default.png'}
+            width={66}
+            height={66}
+            alt="프로필 이미지 미리보기"
+            className="h-[56px] w-[56px] rounded-full md:h-[66px] md:w-[66px]"
+          />
+          <div>
+            <p className="text-base font-bold md:text-2xl">
+              {createrProfile.nickname}
+            </p>
+            <p className="text-sm md:text-base">{createrProfile.email}</p>
+          </div>
+        </div>
+        <Image
+          src={`/myprofile_bg/l/${levelImage}.svg`}
+          width={612}
+          height={224}
+          alt="프로필 배경"
+          className="pointer-events-none absolute top-3 -z-10 hidden lg:-top-1 lg:left-72 lg:block"
+        />
+        <Image
+          src={`/myprofile_bg/l/${levelImage}.svg`}
+          width={540}
+          height={224}
+          alt="프로필 배경"
+          className="pointer-events-none absolute left-16 top-3 -z-10 hidden md:-top-1 md:left-36 md:block lg:hidden"
+        />
+        <Image
+          src={`/myprofile_bg/s/${levelImage}.svg`}
+          width={241}
+          height={121}
+          alt="프로필 배경"
+          className="pointer-events-none absolute left-20 top-5 -z-10 md:hidden"
+        />
+      </div>
+      <hr className="mb-16" />
+      <p className="mb-10 text-lg font-bold">
+        모집글 ({createrProfile.gatherings.length})
+      </p>
+      <GatheringCreaterProfileGatheringList
+        createrGatheringList={createrProfile.gatherings}
+      />
+    </Modal>
+  );
+}

--- a/src/components/gatheringDetail/GatheringCreaterProfileModal.tsx
+++ b/src/components/gatheringDetail/GatheringCreaterProfileModal.tsx
@@ -1,7 +1,10 @@
+/* eslint-disable prettier/prettier */
+
 import Modal from '@/components/@shared/Modal';
 import { GatheringCreaterDTO } from '@/types/gathering.types';
 import Image from 'next/image';
 import GatheringCreaterProfileGatheringList from './GatheringCreaterProfileGatheringList';
+
 interface GatheringCreaterProfileModalProps {
   isModal: boolean;
   onClose: () => void;

--- a/src/data/mockGatheringCreater.ts
+++ b/src/data/mockGatheringCreater.ts
@@ -1,0 +1,40 @@
+import { GatheringCreaterDTO } from '@/types/gathering.types';
+
+export const mockGatheringCreater: GatheringCreaterDTO['get'] = {
+  email: 'moyeobangtester@naver.com', // 사용자 아이디
+  nickname: '모여방테스터', // 사용자 별명
+  image: '', // 사용자 이미지
+  gatherings: [
+    {
+      gatheringId: 1,
+      name: '코드를 그려드립니다',
+      location: 'gangnam',
+      themeName: '마음을 그려그립니다',
+      image: 'https://xdungeon.net/file/theme/11/11_6145641280.jpg',
+      dateTime: '2025-01-15T14:30:00.000Z',
+      capacity: 4,
+      participantCount: 2,
+    },
+    {
+      gatheringId: 2,
+      name: 'And I met Error',
+      location: 'hongdae',
+      themeName: 'And I met E',
+      image: 'https://xdungeon.net/file/theme/18/18_5563125084.png',
+      dateTime: '2025-01-20T18:00:00.000Z',
+      capacity: 6,
+      participantCount: 1,
+    },
+    {
+      gatheringId: 3,
+      name: '13동 안살아서 다행이다',
+      location: 'geondae',
+      themeName: 'B아파트 13동 1313',
+      image:
+        'https://i.postimg.cc/B6ktkgKh/theme-Kakao-Talk-Photo-2019-03-05-17-11-51-4-B-13-1313.jpg',
+      dateTime: '2025-01-25T13:00:00.000Z',
+      capacity: 5,
+      participantCount: 3,
+    },
+  ],
+};

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -59,3 +59,9 @@
 .scrollbar-hidden::-webkit-scrollbar {
   display: none; /* Chrome, Safari, Opera */
 }
+
+@layer utilities {
+  .bg-secondary-80 {
+    background-color: #3e404c;
+  }
+}

--- a/src/types/gathering.types.ts
+++ b/src/types/gathering.types.ts
@@ -101,3 +101,30 @@ export interface LikesGatheringListProps {
     participantCount: number;
   }[];
 }
+
+export interface GatheringCreaterDTO {
+  get: {
+    email: string;
+    nickname: string;
+    image: string;
+    gatherings: {
+      gatheringId: number;
+      name: string;
+      location: string;
+      themeName: string;
+      image: string;
+      dateTime: string;
+      capacity: number;
+      participantCount: number;
+    }[];
+    // reviews: [
+    //   {
+    //     reviewId: number;
+    //     gatheringId: number;
+    //     score: number;
+    //     comment: string;
+    //     createdAt: string;
+    //   },
+    // ];
+  };
+}


### PR DESCRIPTION
## ✏️ 작업 내용 요약

> 이번 PR에서 작업한 내용을 요약해주세요

- 모임상세 모임 주최자 프로필 모달 반응형 레이아웃 구현
- 목데이터를 이용해서 DTO에 입력했습니다.
- 모여방 테스터 101의 데이터로만 보이게 만들었습니다. 
- 아직 review는 구현안했습니다(데이터 가져오기 까다로울 것 같아서..) 
- 모임상세의 전체적인 레이아웃은 정협님 부탁드립니다.

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 모달 bg가 잘 안먹히는 것 같아서 Style.css에 직접 입력하고 important 해주었습니다. 문제가 있거나 이것보다 더 좋은 방안 있다면 말씀해주시길 바랍니다. 

## 🏷️ 연관된 JIRA 번호

- FESI-62

## 📷 스크린샷 (선택)
![1:16_주최자 프로필 모달 구현](https://github.com/user-attachments/assets/324a0994-1986-47b7-bcc7-f79ea12e4fe6)
