### PR TITLE
FESI1-67:  기존 드롭다운 개선 & 정렬 드롭다운 분리

### DIFF
--- a/src/components/@shared/SortDropdown.tsx
+++ b/src/components/@shared/SortDropdown.tsx
@@ -1,26 +1,68 @@
-import Dropdown, {
-  DropdownOption,
-} from '@/components/@shared/dropdown/SelectLocationDropdown';
+import { useState } from 'react';
+import Image from 'next/image';
+import { DropdownOption } from './dropdown/SelectLocationDropdown';
 
 interface SortDropdownProps {
   sortList: DropdownOption[];
   onSortingChange: (value: string) => void;
 }
 
+/**
+ * 정렬 드롭다운
+ *
+ * @param sortList 드롭다운 옵션 배열
+ * @param onSortingChange 선택값 변경 시 호출되는 콜백 함수
+ */
+
 export default function SortDropdown({
   sortList,
   onSortingChange,
 }: SortDropdownProps) {
-  const handleChange = (option: DropdownOption) => {
+  const [selectedOption, setSelectedOption] = useState<DropdownOption>(
+    sortList[0]
+  );
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const handleSelect = (option: DropdownOption) => {
+    setSelectedOption(option);
+    setIsOpen(false);
     onSortingChange(option.value);
   };
 
   return (
-    <Dropdown
-      options={sortList}
-      onChange={handleChange}
-      defaultValue={sortList[0]}
-      icon="/icons/sort.svg"
-    />
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex max-h-[42px] items-center gap-2 rounded-full bg-default-tertiary p-[10px] md:rounded-xl md:px-4 md:py-2"
+      >
+        <Image
+          src="/icons/sort.svg"
+          width={24}
+          height={24}
+          alt="정렬 아이콘"
+          className={`transition-transform duration-300 ease-in-out ${isOpen ? 'rotate-180' : ''}`}
+        />
+        <span className="hidden flex-1 text-sm font-medium text-secondary-40 md:block">
+          {selectedOption.label}
+        </span>
+      </button>
+
+      {isOpen && (
+        <ul className="absolute right-0 z-10 mt-2 w-[120px] overflow-hidden rounded-xl bg-secondary-80 shadow-lg">
+          {sortList.map((option) => (
+            <li key={option.value} className="relative p-0">
+              <button
+                type="button"
+                onClick={() => handleSelect(option)}
+                className="text-white-lg w-full cursor-pointer rounded-[9px] px-4 py-2 text-left text-sm transition-colors duration-150 hover:bg-default-primary"
+              >
+                {option.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }

--- a/src/components/@shared/dropdown/SelectLocationDropdown.tsx
+++ b/src/components/@shared/dropdown/SelectLocationDropdown.tsx
@@ -13,7 +13,7 @@ interface DropdownProps {
   // 드롭다운에 표시할 옵션들의 배열
   options: DropdownOption[];
   // 드롭다운 초기 값
-  defaultValue?: DropdownOption;
+  defaultLabel: string;
   // 옵션 선택 시 호출되는 콜백 함수
   onChange?: (option: DropdownOption) => void;
   // 추가 스타일링 클래스
@@ -24,55 +24,60 @@ interface DropdownProps {
 /**
  * 지역 선택을 위한 드롭다운 컴포넌트
  *
- * @param defaultValue 초기 선택값 (기본값: 지역 전체)
+ * @param defaultLabel 초기 선택 label (EX: 지역)
  * @param onChange 선택값 변경 시 호출되는 콜백 함수
  * @param className 추가 스타일링을 위한 클래스명
  */
 
 export default function Dropdown({
   options,
-  defaultValue,
+  defaultLabel,
   onChange,
   className,
   icon = '/chevron-down.svg',
 }: DropdownProps) {
-  const [selectedOption, setSelectedOption] = useState<DropdownOption>(
-    defaultValue || options[0]
-  );
+  const initialOption: DropdownOption = { value: 'all', label: defaultLabel };
+
+  const [selectedOption, setSelectedOption] =
+    useState<DropdownOption>(initialOption);
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   const handleSelect = (option: DropdownOption) => {
     setSelectedOption(option);
     setIsOpen(false);
     onChange?.(option);
+
+    if (option.value === 'all') {
+      setSelectedOption(initialOption);
+    }
   };
 
   return (
     <div
       className={clsx(
         'relative',
-        { 'min-w-0 md:min-w-[120px]': icon !== '/chevron-down.svg' },
-        { 'min-w-[120px]': icon === '/chevron-down.svg' }
+        { 'min-w-0 md:max-w-[120px]': icon !== '/chevron-down.svg' },
+        { 'max-w-[120px]': icon === '/chevron-down.svg' }
       )}
     >
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
         className={clsx(
-          'h-[42px] w-[120px]',
+          'h-[42px]',
           'relative',
-          'border-2 border-[#808080]',
+          'border-2 border-default-tertiary',
           'rounded-xl',
           'px-4 py-2',
-          'bg-[#2C2C2C]',
+          'bg-default-tertiary',
           'flex items-center',
-          'gap-[2px]',
+          'gap-1',
           { 'w-full flex-row-reverse': icon !== '/chevron-down.svg' },
           className
         )}
       >
         <span
-          className={`${icon !== '/chevron-down.svg' ? 'hidden md:inline-block' : ''} flex-1 text-sm font-medium text-white`}
+          className={`${icon !== '/chevron-down.svg' ? 'hidden md:inline-block' : ''} flex-1 text-sm font-medium text-secondary-40`}
         >
           {selectedOption.label}
         </span>
@@ -91,21 +96,21 @@ export default function Dropdown({
       {isOpen && (
         <ul
           className={clsx(
-            'absolute right-0 z-10 w-[120px]',
+            'absolute right-0 z-10 w-full max-w-[120px]',
             'mt-2',
             'rounded-xl',
-            'bg-[#404048]',
+            'bg-secondary-80',
             'overflow-hidden shadow-lg'
           )}
         >
           {options.map((option) => (
-            <li key={option.value} className="p-0">
+            <li key={option.value} className="relative p-0">
               <button
                 type="button"
                 onClick={() => handleSelect(option)}
                 className={clsx(
                   'w-full cursor-pointer px-4 py-2 text-left text-sm',
-                  'text-white hover:bg-[#4A4A52]',
+                  'text-white-lg rounded-[9px] hover:rounded-[9px] hover:bg-default-primary',
                   'transition-colors duration-150'
                 )}
               >

--- a/src/components/allReview/DateDropdown.tsx
+++ b/src/components/allReview/DateDropdown.tsx
@@ -15,23 +15,23 @@ export default function DateDropdown({ onDateChange }: DateDropdownProps) {
   });
 
   return (
-    <div className={clsx('relative min-w-[120px]')}>
+    <div className={clsx('relative max-w-[120px]')}>
       <button
         type="button"
         onClick={handleChange}
         className={clsx(
-          'h-[42px] w-[120px]',
+          'h-[42px] max-w-[120px]',
           'relative',
           'border-2 border-[#808080]',
           'rounded-xl',
           'px-4 py-2',
           'bg-[#2C2C2C]',
           'flex items-center',
-          'gap-[2px]'
+          'gap-1'
         )}
       >
         <p className="flex-1 text-sm font-medium text-white">
-          {date === '' ? '모든 날짜' : date}
+          {date === '' ? '날짜' : date}
         </p>
         <Image
           src="/chevron-down.svg"
@@ -51,7 +51,7 @@ export default function DateDropdown({ onDateChange }: DateDropdownProps) {
           selectedDate={date}
           onClose={handleChange}
           onDateChange={handleDateChange}
-          layout="top-12 right-[-100px] md:left-0"
+          layout="top-12 md:left-0"
         />
       )}
     </div>

--- a/src/components/allReview/LocationDropdown.tsx
+++ b/src/components/allReview/LocationDropdown.tsx
@@ -19,7 +19,7 @@ export default function LocationDropdown({
     <Dropdown
       options={locationList}
       onChange={handleChange}
-      defaultValue={locationList[0]}
+      defaultLabel="지역"
     />
   );
 }

--- a/src/components/gathering/LevelDropdown.tsx
+++ b/src/components/gathering/LevelDropdown.tsx
@@ -15,10 +15,6 @@ export default function LevelDropdown({ onLevelChange }: LevelDropdownProps) {
   };
 
   return (
-    <Dropdown
-      options={levels}
-      onChange={handleChange}
-      defaultValue={levels[0]}
-    />
+    <Dropdown options={levels} onChange={handleChange} defaultLabel="난이도" />
   );
 }

--- a/src/constants/themeList.ts
+++ b/src/constants/themeList.ts
@@ -68,7 +68,7 @@ export const themeNameList: ThemeNameList = {
 };
 
 export const locationList = [
-  { value: 'all', label: '모든 지역' },
+  { value: 'all', label: '전체' },
   { value: 'geondae', label: '건대' },
   { value: 'hongdae', label: '홍대' },
   { value: 'hyehwa', label: '혜화' },
@@ -89,7 +89,7 @@ export const genres = [
 ];
 
 export const levels = [
-  { value: 'all', label: '모든 난이도' },
+  { value: 'all', label: '전체' },
   { value: '초급', label: '초급' },
   { value: '중급', label: '중급' },
   { value: '고급', label: '고급' },


### PR DESCRIPTION
## ✏️ 작업 내용 요약

> 1. SortDropdown과 Dropdown 컴포넌트 분리
> 2. 기존 Dropdown 개선
> 2-1. defaultValue -> defaultLabel


## 💬 리뷰 요구사항

> 브랜치 분기를 깜빡했네요. 아래에서부터 2번째 커밋까지만 봐주시면 됩니다 😢

- 정렬을 위한 드롭다운과 일반 드롭다운 컴포넌트를 분리했습니다. 정렬 드롭다운 컴포넌트에는 `clsx`를 사용할 일이 없을 것 같아 제거했습니다.

- 기존 드롭다운에서 '전체' 옵션 클릭시 defaultLabel을 보여주도록 구현했습니다. 린트 오류가 없도록 드롭다운을 사용하는 페이지를 수정했습니다.

- 기존 드롭다운의 넓이 값을 변경했습니다. 

## 🏷️ 연관된 JIRA 번호

> FESI1-67

## 📷 스크린샷

> ### 정렬 드롭다운

![image](https://github.com/user-attachments/assets/2a1cd0d7-35b8-4bb7-a9c1-c035f6117e70)

![image](https://github.com/user-attachments/assets/9b28c50e-3020-4bbc-883f-7a549b635b0f)

> ### 드롭다운

![image](https://github.com/user-attachments/assets/6cbe7a29-958e-4bd1-bc10-607061c07a50)

