### PR TITLE
FESI1-104: 추천 테마 참여하기 기능

### DIFF
--- a/src/app/search/[keyword]/page.tsx
+++ b/src/app/search/[keyword]/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+
 import CardMotion from '@/components/@shared/animation/CardMotion';
 import EmptyElement from '@/components/@shared/EmptyElement';
 import Spinner from '@/components/@shared/Spinner';
@@ -8,16 +10,23 @@ import GatheringCard from '@/components/gathering/GatheringCard';
 import { useSearchGathering } from '@/hooks/useSearchGathering';
 import useToast from '@/hooks/useToast';
 import Image from 'next/image';
-import { useState } from 'react';
 
 const searchWords = ['모여방', '팀이', '짱이다'];
-export default function Search() {
-  const [searchKeyword, setSearchKeyword] = useState<string>('');
-  const [searchQuery, setSearchQuery] = useState<string>('');
+
+export default function Search({ params }: { params: { keyword: string } }) {
+  const initialKeyword =
+    params?.keyword && decodeURIComponent(params.keyword) !== 'default-keyword'
+      ? decodeURIComponent(params.keyword)
+      : '';
+
+  const [searchKeyword, setSearchKeyword] = useState<string>(initialKeyword);
+  const [searchQuery, setSearchQuery] = useState<string>(initialKeyword);
 
   const { toastMessage, toastVisible, toastType, handleError } = useToast();
+
   const { data: searchGatherings, isLoading: isGatheringLoading } =
     useSearchGathering(searchQuery);
+
   const handleSearchKeywordChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {

--- a/src/components/@shared/Header.tsx
+++ b/src/components/@shared/Header.tsx
@@ -102,7 +102,7 @@ export default function Header() {
             </nav>
 
             <div className="flex items-center gap-5">
-              <Link href="/search">
+              <Link href="/search/default-keyword">
                 <Image
                   src="/icons/search.svg"
                   width={24}

--- a/src/components/recommend/SurveyResult.tsx
+++ b/src/components/recommend/SurveyResult.tsx
@@ -120,12 +120,7 @@ export default function SurveyResult({
               <RecommendCard themeResult={currentTheme} />
             </section>
             <section className="flex w-full flex-col gap-2">
-              <Link
-                href={{
-                  pathname: '/search',
-                  // query: { keyword: encodeURIComponent(currentTheme.name) },
-                }}
-              >
+              <Link href={`/search/${encodeURIComponent(currentTheme.name)}`}>
                 <Button
                   shape="default"
                   className="w-full border-2 border-primary-5 bg-secondary-90 py-3 text-sm md:border-4 md:py-6 md:text-2xl"


### PR DESCRIPTION
## ✏️ 작업 내용 요약

> 1. '추천 테마 참여하기' 버튼 클릭 시 검색 페이지로 이동
> 2. Search 페이지 경로 이동
> 2-1. `params` 설정
> 2-1. `params`가 default-keyword일 경우 기본 검색 페이지

## 💬 리뷰 요구사항

> ⭐ 이슈에 대한 자세한 사항은 노션 페이지에 있습니다.
  개선 방안이 있다면 코멘트 부탁드립니다!

- '추천 테마 참여하기' 버튼 클릭 시 쿼리 파라미터를 통해 검색 keyword를 전달하려 했으나 지속적인 빌드 에러로 인해 동적 라우팅을 통해 url을 가져오는 방식으로 변경했습니다. 

- 검색 페이지를 하나로 통일하기 위해 GNB에서 검색 아이콘 클릭 시 경로로 `default-keyword`를 전달하게 했습니다. 


## 🏷️ 연관된 JIRA 번호

> FESI1-104

## 📷 스크린샷 

![SHANA 추천 테마 참여하기 경로 이동 기능](https://github.com/user-attachments/assets/8092c9a7-cf01-4037-ace3-4d6df2fe5778)

