### PR TITLE
FESI1-107: 모임 목록 가상 스크롤 구현 & 홈 페이지 리팩토링

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "clsx": "^2.1.1",
         "framer-motion": "^12.1.0",
         "next": "^14.1.0",
+        "node-cache": "^5.1.2",
         "qs": "^6.14.0",
         "react": "^18",
         "react-calendar": "^5.1.0",
@@ -22,6 +23,7 @@
         "react-intersection-observer": "^9.15.1",
         "react-redux": "^9.2.0",
         "react-slick": "^0.30.3",
+        "react-virtualized": "^9.22.6",
         "redux": "^5.0.1",
         "slick-carousel": "^1.8.1",
         "ts-node": "^10.9.2"
@@ -33,6 +35,7 @@
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "@types/react-slick": "^0.23.13",
+        "@types/react-virtualized": "^9.22.2",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "autoprefixer": "^10.0.1",
@@ -2526,6 +2529,17 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-virtualized": {
+      "version": "9.22.2",
+      "resolved": "https://registry.npmjs.org/@types/react-virtualized/-/react-virtualized-9.22.2.tgz",
+      "integrity": "sha512-0Eg/ME3OHYWGxs+/n4VelfYrhXssireZaa1Uqj5SEkTpSaBu5ctFGOCVxcOqpGXRiEdrk/7uho9tlZaryCIjHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
@@ -3388,6 +3402,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -3599,8 +3622,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3775,6 +3797,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -6253,6 +6285,18 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -6293,7 +6337,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6891,7 +6934,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -7039,8 +7081,13 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -7080,6 +7127,33 @@
       "peerDependencies": {
         "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-virtualized": {
+      "version": "9.22.6",
+      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.6.tgz",
+      "integrity": "sha512-U5j7KuUQt3AaMatlMJ0UJddqSiX+Km0YJxSqbAzIiGw5EmNz0khMyqP2hzgu4+QUtm+QPIrxzUX4raJxmVJnHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "clsx": "^1.0.4",
+        "dom-helpers": "^5.1.3",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-virtualized/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "preview": "next start"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.62.16",
@@ -14,6 +15,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^12.1.0",
     "next": "^14.1.0",
+    "node-cache": "^5.1.2",
     "qs": "^6.14.0",
     "react": "^18",
     "react-calendar": "^5.1.0",
@@ -23,6 +25,7 @@
     "react-intersection-observer": "^9.15.1",
     "react-redux": "^9.2.0",
     "react-slick": "^0.30.3",
+    "react-virtualized": "^9.22.6",
     "redux": "^5.0.1",
     "slick-carousel": "^1.8.1",
     "ts-node": "^10.9.2"
@@ -34,6 +37,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@types/react-slick": "^0.23.13",
+    "@types/react-virtualized": "^9.22.2",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "autoprefixer": "^10.0.1",

--- a/src/app/gathering/page.tsx
+++ b/src/app/gathering/page.tsx
@@ -7,7 +7,7 @@ import Spinner from '@/components/@shared/Spinner';
 
 export default function Gathering() {
   return (
-    <div className="flex h-full w-full flex-col gap-12 px-4 py-24 md:px-6 md:py-32 xl:mx-auto xl:max-w-[1166px] xl:px-0">
+    <div className="flex h-full w-full flex-col gap-12 px-4 pb-12 pt-24 md:px-6 md:pt-32 xl:mx-auto xl:max-w-[1166px] xl:px-0">
       <HeaderTitle
         title="모임 찾기"
         h1="지금 여기로 모여방"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,17 @@
 import type { Metadata } from 'next';
+import localFont from 'next/font/local';
+
 import Header from '../components/@shared/Header';
 import { Providers } from '../providers/providers';
 import '../styles/globals.css';
 import '../styles/scrollbar.css';
+
+const pretendard = localFont({
+  src: '../../public/fonts/PretendardVariable.woff2',
+  display: 'swap',
+  weight: '45 920',
+  variable: '--font-pretendard',
+});
 
 export const metadata: Metadata = {
   title: '모여방',
@@ -45,7 +54,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="ko">
+    <html
+      lang="ko"
+      className={`${pretendard.variable} ${pretendard.className}`}
+    >
       <body className="scrollbar-x-hidden default-scrollbar">
         <Providers>
           <Header />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,10 @@
 import { Suspense } from 'react';
 
+import {
+  getGatheringsDateTime,
+  getGatheringsByRegistrationEnd,
+} from '@/axios/gather/apis';
+
 import SkeletonCardList from '@/components/@shared/skeleton/SkeletonCardList';
 import SkeletonSlotList from '@/components/@shared/skeleton/SkeletonSlotList';
 import Carousel from '@/components/home/UI/Carousel';
@@ -8,28 +13,29 @@ import LinkButton from '@/components/@shared/button/LinkButton';
 import NearRecent from '@/components/home/NearRecent';
 import NearDeadlines from '@/components/home/NearDeadlines';
 
-export default function Home() {
+export default async function Home() {
+  const gatheringsDateTime = await getGatheringsDateTime();
+  const gatheringsRegistrationEnd = await getGatheringsByRegistrationEnd();
+
   return (
     <>
-      <div className="mx-auto flex h-full max-w-6xl flex-col gap-12 px-4 pb-16 pt-20 md:gap-20 md:pb-24 md:pt-28 xl:px-0 xl:pb-32 xl:pt-32">
+      <main className="mx-auto flex h-full max-w-6xl flex-col gap-12 px-4 pb-16 pt-20 md:gap-20 md:pb-24 md:pt-28 xl:px-0 xl:pb-32 xl:pt-32">
         <Carousel />
-        <main className="flex flex-col items-center ">
-          <div className="mb-12 flex w-full flex-col items-start gap-2 md:mb-20">
+        <section className="flex flex-col items-center gap-12 md:gap-20">
+          <div className="flex w-full flex-col items-start gap-2">
             <h2 className="text-sm font-medium">함께 할 사람이 없나요?</h2>
             <h1 className="text-2xl font-semibold">지금 여기로 모여방</h1>
           </div>
           <Suspense fallback={<SkeletonCardList />}>
-            <NearRecent />
+            <NearRecent gatherings={gatheringsDateTime} />
           </Suspense>
-          <div className="mt-12 md:mt-20">
-            <LinkButton href="/gathering" variant="dark" size="long">
-              모여방 더보기
-            </LinkButton>
-          </div>
-        </main>
-      </div>
+          <LinkButton href="/gathering" variant="dark" size="long">
+            모여방 더보기
+          </LinkButton>
+        </section>
+      </main>
       <Suspense fallback={<SkeletonSlotList />}>
-        <NearDeadlines />
+        <NearDeadlines gatherings={gatheringsRegistrationEnd} />
       </Suspense>
       <Links />
     </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,14 @@
 import { Suspense } from 'react';
 
-import {
-  getGatheringsDateTime,
-  getGatheringsByRegistrationEnd,
-} from '@/axios/gather/apis';
-
 import SkeletonCardList from '@/components/@shared/skeleton/SkeletonCardList';
 import SkeletonSlotList from '@/components/@shared/skeleton/SkeletonSlotList';
 import Carousel from '@/components/home/UI/Carousel';
 import Links from '@/components/home/Links';
 import LinkButton from '@/components/@shared/button/LinkButton';
-import NearRecent from '@/components/home/NearRecent';
-import NearDeadlines from '@/components/home/NearDeadlines';
+import NearRecentSection from '@/components/home/NearRecentSection';
+import NearDeadlinesSection from '@/components/home/NearDeadlinesSection';
 
-export default async function Home() {
-  const gatheringsDateTime = await getGatheringsDateTime();
-  const gatheringsRegistrationEnd = await getGatheringsByRegistrationEnd();
-
+export default function Home() {
   return (
     <>
       <main className="mx-auto flex h-full max-w-6xl flex-col gap-12 px-4 pb-16 pt-20 md:gap-20 md:pb-24 md:pt-28 xl:px-0 xl:pb-32 xl:pt-32">
@@ -27,7 +19,7 @@ export default async function Home() {
             <h1 className="text-2xl font-semibold">지금 여기로 모여방</h1>
           </div>
           <Suspense fallback={<SkeletonCardList />}>
-            <NearRecent gatherings={gatheringsDateTime} />
+            <NearRecentSection />
           </Suspense>
           <LinkButton href="/gathering" variant="dark" size="long">
             모여방 더보기
@@ -35,7 +27,7 @@ export default async function Home() {
         </section>
       </main>
       <Suspense fallback={<SkeletonSlotList />}>
-        <NearDeadlines gatherings={gatheringsRegistrationEnd} />
+        <NearDeadlinesSection />
       </Suspense>
       <Links />
     </>

--- a/src/components/gathering/GatheringList.tsx
+++ b/src/components/gathering/GatheringList.tsx
@@ -1,15 +1,15 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
 import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 
 import type { GatheringDto } from '@/types/gathering.types';
 import { getGatherings } from '@/axios/gather/apis';
 import { sortList } from '@/constants/sortList';
+
 import { INIT_GATHERING } from '@/constants/initialValues';
 import { QueryProvider } from '@/components/@shared/QueryProvider';
-import useInfiniteScroll from '@/hooks/useInfiniteScroll';
-
 import EmptyElement from '@/components/@shared/EmptyElement';
 import GatheringCard from '@/components/gathering/GatheringCard';
 import DateDropdown from '@/components/@shared/dropdown/DateDropdown';
@@ -19,58 +19,102 @@ import SortDropdown from '@/components/@shared/dropdown/SortDropdown';
 import GenreFilter from '@/components/@shared/GenreFilter';
 
 export default function GatheringList() {
-  const [selectedSort, setSelectedSort] = useState('dateTime');
+  const { ref: targetRef, inView } = useInView();
+  const [pageParam, setPageParam] = useState(0);
+  const [selectedSort, setSelectedSort] = useState(INIT_GATHERING.SORT.sortBy);
   const [filters, setFilters] = useState(INIT_GATHERING.FILTER);
+  const [initialScrollRestored, setInitialScrollRestored] = useState(false);
 
+  const queryKey = ['gatherings', filters, selectedSort];
+
+  // 필터 및 정렬 상태를 세션 스토리지에 저장
+  useEffect(() => {
+    if (initialScrollRestored && typeof window !== 'undefined') {
+      const stateToSave = {
+        savedSort: selectedSort,
+        savedFilters: filters,
+        savedScrollY: window.scrollY,
+      };
+      sessionStorage.setItem('gatheringState', JSON.stringify(stateToSave));
+    }
+  }, [selectedSort, filters, pageParam, initialScrollRestored]);
+
+  // 초기 로드 시 저장된 상태 불러오기
+  useEffect(() => {
+    const savedState = sessionStorage.getItem('gatheringState');
+    if (savedState) {
+      try {
+        const state = JSON.parse(savedState);
+        setSelectedSort(state.savedSort);
+        setFilters(state.savedFilters);
+        setPageParam(state.savedPageParam || 0);
+
+        if (state.savedScrollY) {
+          window.scrollTo(0, state.savedScrollY);
+        }
+        setInitialScrollRestored(true);
+      } catch (e) {
+        console.error('상태 불러오기 오류:', e);
+      }
+    } else {
+      setInitialScrollRestored(true);
+    }
+  }, []);
+
+  // 모임 목록 무한스크롤
   const {
     data: gatherings,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
   } = useSuspenseInfiniteQuery({
-    queryKey: ['gatherings', filters, selectedSort],
-    queryFn: async ({ pageParam = 0 }) => {
+    queryKey,
+    queryFn: async ({ pageParam: fetchPageParam }) => {
       const response = await getGatherings({
-        limit: 10,
-        sortOrder: 'asc',
+        limit: 2,
+        offset: fetchPageParam,
+        sortOrder: INIT_GATHERING.SORT.sortOrder,
         sortBy: selectedSort,
-        level: filters.level,
-        location: filters.location,
-        genre: filters.genre,
-        date: filters.date,
-        offset: pageParam,
+        ...filters,
       });
 
       return response;
     },
-    getNextPageParam: (lastPage, allPages, lastPageParam) => {
-      // 추가 데이터 요청 여부 판별
-      if (!lastPage || lastPage.length < 10) return undefined;
+    getNextPageParam: (lastPage, allPages) => {
+      const nextPage = allPages.length;
 
-      // offset이 page처럼 동작, 1씩 증가하도록 설정
-      return lastPageParam + 1;
+      return !lastPage || lastPage.length < 2 ? undefined : nextPage;
     },
     initialPageParam: 0,
+    gcTime: 1000 * 60 * 60 * 24, // 24시간
+    staleTime: 1000 * 60 * 10, // 10분
   });
 
   const allGatherings = gatherings.pages.flat();
 
-  const handleFilterChange = (key: string, value: any) => {
+  // 데이터 추가 요청
+  useEffect(() => {
+    if (!inView || !hasNextPage || isFetchingNextPage) {
+      return;
+    }
+
+    setPageParam((prev) => prev + 1);
+    fetchNextPage();
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  // 필터 및 정렬 변경 핸들러
+  const handleFilterChange = (
+    key: keyof typeof INIT_GATHERING.FILTER,
+    value: string
+  ) => {
     setFilters((prev) => ({ ...prev, [key]: value }));
+    setPageParam(0);
   };
 
   const onSortingChange = (sortOption: string) => {
     setSelectedSort(sortOption);
+    setPageParam(0);
   };
-
-  // 추가 데이터 요청 함수
-  const loadMore = () => {
-    if (hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
-    }
-  };
-
-  const { targetRef } = useInfiniteScroll(loadMore, hasNextPage);
 
   return (
     <QueryProvider>
@@ -106,12 +150,12 @@ export default function GatheringList() {
           </div>
         </div>
       </section>
-
       {allGatherings.length > 0 ? (
         <section className="mx-auto grid h-full w-full grid-cols-1 gap-3 text-white xl:grid-cols-2">
           {allGatherings.map((gathering: GatheringDto['get']) => (
             <GatheringCard key={gathering.gatheringId} {...gathering} />
           ))}
+          <div ref={targetRef} style={{ height: '1px' }} />
         </section>
       ) : (
         <EmptyElement>
@@ -120,7 +164,6 @@ export default function GatheringList() {
           지금 바로 모임을 만들어보세요
         </EmptyElement>
       )}
-      <div ref={targetRef} style={{ height: '1px' }} />
     </QueryProvider>
   );
 }

--- a/src/components/gathering/GatheringList.tsx
+++ b/src/components/gathering/GatheringList.tsx
@@ -3,8 +3,13 @@
 import { useState, useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
+import {
+  List,
+  AutoSizer,
+  CellMeasurer,
+  CellMeasurerCache,
+} from 'react-virtualized';
 
-import type { GatheringDto } from '@/types/gathering.types';
 import { getGatherings } from '@/axios/gather/apis';
 import { sortList } from '@/constants/sortList';
 
@@ -19,13 +24,58 @@ import SortDropdown from '@/components/@shared/dropdown/SortDropdown';
 import GenreFilter from '@/components/@shared/GenreFilter';
 
 export default function GatheringList() {
-  const { ref: targetRef, inView } = useInView();
   const [pageParam, setPageParam] = useState(0);
   const [selectedSort, setSelectedSort] = useState(INIT_GATHERING.SORT.sortBy);
   const [filters, setFilters] = useState(INIT_GATHERING.FILTER);
   const [initialScrollRestored, setInitialScrollRestored] = useState(false);
+  const [visibleStartIndex, setVisibleStartIndex] = useState(0);
+  const [visibleEndIndex, setVisibleEndIndex] = useState(2);
+  const [isMobile, setIsMobile] = useState(false);
+  const { ref: bottomObserverRef, inView: bottomInView } = useInView();
 
   const queryKey = ['gatherings', filters, selectedSort];
+
+  // 모임 목록 무한스크롤
+  const {
+    data: gatherings,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useSuspenseInfiniteQuery({
+    queryKey,
+    queryFn: async ({ pageParam: fetchPageParam }) => {
+      const response = await getGatherings({
+        limit: 5,
+        offset: fetchPageParam,
+        sortOrder: INIT_GATHERING.SORT.sortOrder,
+        sortBy: selectedSort,
+        ...filters,
+      });
+
+      return response;
+    },
+    getNextPageParam: (lastPage, allPages) => {
+      const nextPage = allPages.length;
+
+      return !lastPage || lastPage.length < 5 ? undefined : nextPage;
+    },
+    initialPageParam: 0,
+    gcTime: 1000 * 60 * 60 * 24, // 24시간
+    staleTime: 1000 * 60 * 10, // 10분
+  });
+
+  const allGatherings = gatherings.pages.flat();
+
+  // react-virtualized를 위한 CellMeasurer 캐시 설정
+  const cache = new CellMeasurerCache({
+    fixedWidth: true,
+    defaultHeight: isMobile ? 120 : 178,
+    keyMapper: (index: number) => {
+      // 각 아이템에 고유한 키를 제공하여 캐싱 문제 방지
+      if (!allGatherings || !allGatherings[index]) return String(index);
+      return String(allGatherings[index]?.id || index);
+    },
+  });
 
   // 필터 및 정렬 상태를 세션 스토리지에 저장
   useEffect(() => {
@@ -61,46 +111,15 @@ export default function GatheringList() {
     }
   }, []);
 
-  // 모임 목록 무한스크롤
-  const {
-    data: gatherings,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  } = useSuspenseInfiniteQuery({
-    queryKey,
-    queryFn: async ({ pageParam: fetchPageParam }) => {
-      const response = await getGatherings({
-        limit: 2,
-        offset: fetchPageParam,
-        sortOrder: INIT_GATHERING.SORT.sortOrder,
-        sortBy: selectedSort,
-        ...filters,
-      });
-
-      return response;
-    },
-    getNextPageParam: (lastPage, allPages) => {
-      const nextPage = allPages.length;
-
-      return !lastPage || lastPage.length < 2 ? undefined : nextPage;
-    },
-    initialPageParam: 0,
-    gcTime: 1000 * 60 * 60 * 24, // 24시간
-    staleTime: 1000 * 60 * 10, // 10분
-  });
-
-  const allGatherings = gatherings.pages.flat();
-
   // 데이터 추가 요청
   useEffect(() => {
-    if (!inView || !hasNextPage || isFetchingNextPage) {
+    if (!bottomInView || !hasNextPage || isFetchingNextPage) {
       return;
     }
 
     setPageParam((prev) => prev + 1);
     fetchNextPage();
-  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
+  }, [bottomInView, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   // 필터 및 정렬 변경 핸들러
   const handleFilterChange = (
@@ -109,11 +128,112 @@ export default function GatheringList() {
   ) => {
     setFilters((prev) => ({ ...prev, [key]: value }));
     setPageParam(0);
+    cache.clearAll();
   };
 
   const onSortingChange = (sortOption: string) => {
     setSelectedSort(sortOption);
     setPageParam(0);
+    cache.clearAll();
+  };
+
+  // 미디어 쿼리로 모바일 상태 판단
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+
+    const mediaQuery = window.matchMedia('(max-width: 767px)');
+
+    // 초기 상태 설정
+    setIsMobile(mediaQuery.matches);
+
+    // 미디어 쿼리 변경 리스너
+    const handleMediaQueryChange = (event: MediaQueryListEvent) => {
+      setIsMobile(event.matches);
+    };
+
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener('change', handleMediaQueryChange);
+    } else {
+      // 이전 버전 브라우저 지원
+      mediaQuery.addListener(handleMediaQueryChange);
+    }
+
+    // eslint-disable-next-line consistent-return
+    return () => {
+      if (mediaQuery.removeEventListener) {
+        mediaQuery.removeEventListener('change', handleMediaQueryChange);
+      } else {
+        mediaQuery.removeListener(handleMediaQueryChange);
+      }
+    };
+  }, []);
+
+  // 뷰포트에 보이는 데이터 계산
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+
+    const rowHeight = isMobile ? 116 : 170;
+    const viewportHeight = document.documentElement.clientHeight;
+    const visibleRowCount = Math.ceil(viewportHeight / rowHeight);
+
+    setVisibleStartIndex(Math.max(0, pageParam * 2 - visibleRowCount));
+    setVisibleEndIndex((pageParam + 1) * 2 + visibleRowCount);
+  }, [pageParam, isMobile]);
+
+  useEffect(() => {
+    cache.clearAll();
+  }, [isMobile]);
+
+  // 필터 변경시 캐시 초기화
+  useEffect(() => {
+    if (cache) {
+      cache.clearAll();
+    }
+  }, [filters, selectedSort]);
+
+  // 행 렌더링 함수
+  const rowRenderer = ({
+    index,
+    key,
+    parent,
+    style,
+  }: {
+    index: number;
+    key: string;
+    parent: any;
+    style: React.CSSProperties;
+  }) => {
+    const item = allGatherings[index];
+    const rowHeight = isMobile ? 116 : 178;
+    const marginBottom = isMobile ? 4 : 8;
+
+    // 마지막 요소에 관찰자 참조 추가
+    const isLastItem = index === allGatherings.length - 1;
+
+    // 고유한 키 생성
+    const itemKey = item?.id || index;
+
+    return (
+      <CellMeasurer
+        key={`${itemKey}-${filters.genre}-${filters.date}-${filters.location}-${filters.level}-${selectedSort}`}
+        cache={cache}
+        parent={parent}
+        columnIndex={0}
+        rowIndex={index}
+      >
+        <div
+          style={{
+            ...style,
+            height: rowHeight,
+            marginBottom: `${marginBottom}px`,
+            boxSizing: 'border-box',
+          }}
+        >
+          <GatheringCard {...item} key={`card-${itemKey}-${filters.genre}`} />
+          {isLastItem && <div ref={bottomObserverRef} className="h-[1px]" />}
+        </div>
+      </CellMeasurer>
+    );
   };
 
   return (
@@ -150,13 +270,40 @@ export default function GatheringList() {
           </div>
         </div>
       </section>
+
       {allGatherings.length > 0 ? (
-        <section className="mx-auto grid h-full w-full grid-cols-1 gap-3 text-white xl:grid-cols-2">
-          {allGatherings.map((gathering: GatheringDto['get']) => (
-            <GatheringCard key={gathering.gatheringId} {...gathering} />
-          ))}
-          <div ref={targetRef} style={{ height: '1px' }} />
-        </section>
+        <div
+          className="w-full"
+          style={{
+            height: isMobile ? 'calc(100vh - 30vh)' : 'calc(100vh - 24vh)',
+            position: 'relative',
+          }}
+        >
+          <AutoSizer>
+            {({ height, width }) => (
+              <List
+                height={height}
+                width={width}
+                rowCount={allGatherings.length}
+                rowHeight={isMobile ? 120 : 178}
+                rowRenderer={rowRenderer}
+                deferredMeasurementCache={cache}
+                overscanRowCount={5}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  paddingRight: '4px',
+                }}
+                // 필터나 정렬이 변경되면 List를 강제로 다시 렌더링
+                key={`list-${filters.genre}-${filters.date}-${filters.location}-${filters.level}-${selectedSort}`}
+              />
+            )}
+          </AutoSizer>
+          <div ref={bottomObserverRef} className="absolute bottom-0 h-[1px]" />
+        </div>
       ) : (
         <EmptyElement>
           아직 모임이 없어요,

--- a/src/components/home/NearDeadlines.tsx
+++ b/src/components/home/NearDeadlines.tsx
@@ -1,90 +1,92 @@
 'use client';
 
-import Image from 'next/image';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useState, useEffect } from 'react';
 
+import Image from 'next/image';
 import usePagination from '@/hooks/usePagination';
-import { QueryProvider } from '@/components/@shared/QueryProvider';
 import Pagination from '@/components/@shared/Pagination';
 import GatheringSlot from '@/components/home/UI/GatheringSlot';
+import SkeletonSlotList from '../@shared/skeleton/SkeletonSlotList';
 
-import { getGatheringsByRegistrationEnd } from '@/axios/gather/apis';
-
-export default function NearDeadlines() {
-  const { data: gatherings } = useSuspenseQuery({
-    queryKey: ['gatherings/registrationEnd'],
-    queryFn: getGatheringsByRegistrationEnd,
-  });
-
+export default function NearDeadlines({ gatherings }: { gatherings: any[] }) {
+  const [isLoading, setIsLoading] = useState(true);
   const { currentItems, currentPage, handleNextPage, handlePrevPage } =
     usePagination(gatherings, 2);
 
-  return (
-    <QueryProvider>
-      <section className="w-full bg-primary-20">
-        <div className="mx-auto flex h-full max-w-6xl flex-col px-6 md:flex-row md:gap-6 md:px-4 xl:px-0">
-          <div className="mt-6 flex flex-1 flex-col gap-3 md:relative md:my-4 md:mt-5 md:gap-0 xl:my-10 xl:gap-11">
-            <div className="flex md:items-end xl:items-center xl:justify-between">
-              <h1 className="mb-0 w-full text-lg font-semibold text-secondary-bg md:mb-10 md:w-auto md:text-2xl xl:mb-0 xl:w-full">
-                마감 임박! 빨리 모여방
-              </h1>
-              <Pagination
-                currentPage={currentPage}
-                totalItems={gatherings.length}
-                itemsPerPage={2}
-                onNext={handleNextPage}
-                onPrev={handlePrevPage}
-                className="mb-0 flex items-center md:mb-11 md:ml-14 md:flex-1 xl:mb-0 xl:ml-0 xl:flex-auto"
-              />
-              <Image
-                src="/images/puzzle_deadline_tb.png"
-                alt="마감 임박 퍼즐 캐릭터"
-                width={204}
-                height={158}
-                quality={100}
-                className="mt-auto hidden max-h-full md:block xl:hidden"
-              />
-            </div>
-            {currentItems.length > 0 ? (
-              <div className="grid grid-cols-1 grid-rows-1 gap-3 md:grid-cols-2 md:gap-7">
-                {currentItems.map((gathering: any) => (
-                  <GatheringSlot
-                    key={gathering.gatheringId}
-                    gatheringId={gathering.gatheringId}
-                    registrationEnd={gathering.registrationEnd}
-                    name={gathering.name}
-                    capacity={gathering.capacity}
-                    participantCount={gathering.participantCount}
-                    image={gathering.image}
-                  />
-                ))}
-              </div>
-            ) : (
-              <div className="mb-6 mt-12 flex flex-1 items-center justify-center text-default-tertiary md:mb-20 md:mt-16 xl:my-0">
-                마감 임박 모임을 불러오지 못했어요.
-              </div>
-            )}
-          </div>
-          <div className="ml-auto mt-2 max-h-[109px] max-w-[153px] md:hidden">
+  // 로딩 지연
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsLoading(false);
+    }, 200);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return isLoading ? (
+    <SkeletonSlotList />
+  ) : (
+    <section className="w-full bg-primary-20">
+      <div className="mx-auto flex h-full max-w-6xl flex-col px-6 md:flex-row md:gap-6 md:px-4 xl:px-0">
+        <div className="mt-6 flex flex-1 flex-col gap-3 md:relative md:my-4 md:mt-5 md:gap-0 xl:my-10 xl:gap-11">
+          <div className="flex md:items-end xl:items-center xl:justify-between">
+            <h1 className="mb-0 w-full text-lg font-semibold text-secondary-bg md:mb-10 md:w-auto md:text-2xl xl:mb-0 xl:w-full">
+              마감 임박! 빨리 모여방
+            </h1>
+            <Pagination
+              currentPage={currentPage}
+              totalItems={gatherings.length}
+              itemsPerPage={2}
+              onNext={handleNextPage}
+              onPrev={handlePrevPage}
+              className="mb-0 flex items-center md:mb-11 md:ml-14 md:flex-1 xl:mb-0 xl:ml-0 xl:flex-auto"
+            />
             <Image
-              src="/images/puzzle_deadline_mb.png"
+              src="/images/puzzle_deadline_tb.png"
               alt="마감 임박 퍼즐 캐릭터"
+              width={204}
+              height={158}
               quality={100}
-              width={109}
-              height={153}
-              className="max-h-full max-w-full"
+              className="mt-auto hidden max-h-full md:block xl:hidden"
             />
           </div>
+          {currentItems.length > 0 ? (
+            <div className="grid grid-cols-1 grid-rows-1 gap-3 md:grid-cols-2 md:gap-7">
+              {currentItems.map((gathering) => (
+                <GatheringSlot
+                  key={gathering.gatheringId}
+                  gatheringId={gathering.gatheringId}
+                  registrationEnd={gathering.registrationEnd}
+                  name={gathering.name}
+                  capacity={gathering.capacity}
+                  participantCount={gathering.participantCount}
+                  image={gathering.image}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="mb-6 mt-12 flex flex-1 items-center justify-center text-default-tertiary md:mb-20 md:mt-16 xl:my-0">
+              마감 임박 모임을 불러오지 못했어요.
+            </div>
+          )}
+        </div>
+        <div className="ml-auto mt-2 max-h-[109px] max-w-[153px] md:hidden">
           <Image
-            src="/images/puzzle_deadline_pc.png"
+            src="/images/puzzle_deadline_mb.png"
             alt="마감 임박 퍼즐 캐릭터"
             quality={100}
-            width={487}
-            height={466}
-            className="mt-auto hidden md:hidden xl:block xl:max-h-[466px] xl:max-w-[457px]"
+            width={109}
+            height={153}
+            className="max-h-full max-w-full"
           />
         </div>
-      </section>
-    </QueryProvider>
+        <Image
+          src="/images/puzzle_deadline_pc.png"
+          alt="마감 임박 퍼즐 캐릭터"
+          quality={100}
+          width={487}
+          height={466}
+          className="mt-auto hidden md:hidden xl:block xl:max-h-[466px] xl:max-w-[457px]"
+        />
+      </div>
+    </section>
   );
 }

--- a/src/components/home/NearDeadlinesSection.tsx
+++ b/src/components/home/NearDeadlinesSection.tsx
@@ -1,0 +1,8 @@
+import { getGatheringsByRegistrationEnd } from '@/axios/gather/apis';
+import NearDeadlines from '@/components/home/NearDeadlines';
+
+export default async function NearDeadlinesSection() {
+  const gatheringsRegistrationEnd = await getGatheringsByRegistrationEnd();
+
+  return <NearDeadlines gatherings={gatheringsRegistrationEnd} />;
+}

--- a/src/components/home/NearRecent.tsx
+++ b/src/components/home/NearRecent.tsx
@@ -1,32 +1,22 @@
 'use client';
 
-import { useSuspenseQuery } from '@tanstack/react-query';
-
-import { QueryProvider } from '@/components/@shared/QueryProvider';
 import EmptyElement from '@/components/@shared/EmptyElement';
 import GatheringCard from '@/components/gathering/GatheringCard';
 
-import { getGatheringsDateTime } from '@/axios/gather/apis';
-
-export default function NearRecent() {
-  const { data: gatherings } = useSuspenseQuery({
-    queryKey: ['gatherings/dateTime'],
-    queryFn: getGatheringsDateTime,
-  });
-
+export default function NearRecent({ gatherings }: { gatherings: any[] }) {
   return (
-    <QueryProvider>
+    <div className="w-full">
       {gatherings.length > 0 ? (
-        <section className="grid h-full w-full grid-cols-1 grid-rows-2 gap-4 md:gap-7 xl:grid-cols-2 xl:grid-rows-2 xl:gap-9">
-          {gatherings.map((gathering: any) => (
+        <div className="grid h-full w-full grid-cols-1 grid-rows-2 gap-4 md:gap-7 xl:grid-cols-2 xl:grid-rows-2 xl:gap-9">
+          {gatherings.map((gathering) => (
             <GatheringCard key={gathering.gatheringId} {...gathering} />
           ))}
-        </section>
+        </div>
       ) : (
         <EmptyElement className="w-full">
           모집 중인 모임을 불러오지 못했어요.
         </EmptyElement>
       )}
-    </QueryProvider>
+    </div>
   );
 }

--- a/src/components/home/NearRecentSection.tsx
+++ b/src/components/home/NearRecentSection.tsx
@@ -1,0 +1,8 @@
+import { getGatheringsDateTime } from '@/axios/gather/apis';
+import NearRecent from '@/components/home/NearRecent';
+
+export default async function NearRecentSection() {
+  const gatheringsDateTime = await getGatheringsDateTime();
+
+  return <NearRecent gatherings={gatheringsDateTime} />;
+}

--- a/src/constants/initialValues.ts
+++ b/src/constants/initialValues.ts
@@ -20,6 +20,10 @@ export const INIT_GATHERING = {
   DELETE: {
     gatheringId: 0,
   },
+  SORT: {
+    sortBy: 'dateTime',
+    sortOrder: 'asc',
+  },
   FILTER: {
     genre: '',
     location: '',

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,18 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
-@font-face {
-  font-family: 'Pretendard';
-  src: url('/fonts/PretendardVariable.woff2') format('woff2');
-}
-
-:root {
-  --font-pretendard: 'Pretendard', sans-serif;
-}
-
 @layer base {
   html {
-    @apply antialiased;
+    @apply font-pretendard antialiased;
   }
 
   body {

--- a/src/styles/scrollbar.css
+++ b/src/styles/scrollbar.css
@@ -58,3 +58,15 @@
 .scrollbar-x-hidden {
   scrollbar-width: none;
 }
+
+.scrollbar-y-hidden {
+  overflow-y: auto;
+}
+
+.scrollbar-y-hidden::-webkit-scrollbar {
+  display: none;
+}
+
+.scrollbar-y-hidden {
+  scrollbar-width: none;
+}

--- a/src/utils/apiCall.ts
+++ b/src/utils/apiCall.ts
@@ -1,6 +1,10 @@
 import { publicAxiosInstance, authAxiosInstance } from '@/axios/axiosInstance';
 import qs from 'qs';
 import { AxiosRequestConfig } from 'axios';
+import NodeCache from 'node-cache';
+
+// 캐시 유효 시간: 60초
+const apiCache = new NodeCache({ stdTTL: 60 });
 
 type HttpMethod = 'get' | 'post' | 'patch' | 'delete' | 'put';
 
@@ -13,6 +17,16 @@ export const apiCall = async (
 ) => {
   try {
     const { params: queryParams, ...axiosConfig } = config;
+
+    // 캐시 확인
+    if (method === 'get') {
+      const cacheKey = `${url}:${JSON.stringify(queryParams)}`;
+      const cachedData = apiCache.get(cacheKey);
+
+      if (cachedData) {
+        return cachedData;
+      }
+    }
 
     const axiosInstance =
       method === 'get' ? publicAxiosInstance : authAxiosInstance;
@@ -36,6 +50,13 @@ export const apiCall = async (
     }
 
     const response = await axiosInstance.request(requestConfig);
+
+    // 캐시 저장
+    if (method === 'get') {
+      const cacheKey = `${url}:${JSON.stringify(queryParams)}`;
+      apiCache.set(cacheKey, response.data);
+    }
+
     return response.data;
   } catch (error) {
     console.error('API call error:', error);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,6 +4,15 @@ const config: Config = {
   content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
     extend: {
+      fontFamily: {
+        pretendard: [
+          'var(--font-pretendard)',
+          'sans-serif',
+          'system-ui',
+          'Apple SD Gothic Neo',
+          'AppleGothic',
+        ],
+      },
       colors: {
         default: {
           primary: '#6659F4',
@@ -64,9 +73,7 @@ const config: Config = {
           secondary: '#F5F7FD',
         },
       },
-      fontFamily: {
-        sans: 'var(--font-pretendard), -apple-system, BlinkMacSystemFont, system-ui, Roboto, sans-serif',
-      },
+
       spacing: {
         '1/10': '10%',
         '1/5': '20%',


### PR DESCRIPTION
## ✏️ 작업 내용 요약

> 1. 모임 목록 가상 스크롤 구현
> 2. 모임 목록 페이지 재 진입 시 이전 정렬/필터 상태 복원
> 3. 홈 페이지 SSR, 캐싱, 스트리밍
> 4. localFont 적용

## 💬 리뷰 요구사항 

> ⚠️ react-virtualized, NodeCache를 설치했습니다.

- 가상 스크롤을 위해 모임 목록 디자인을 변경한 부분이 있습니다.
- 홈페이지 SSR으로 페이지 응답 속도를 50% 단축했습니다.

## 🏷️ 연관된 JIRA 번호

> FESI1-107

## 📷 스크린샷

> ### 가상 스크롤

![SHANA K-040](https://github.com/user-attachments/assets/c94ed15e-b45b-4da8-87fc-2dbbf24cec0a)

> ### 페이지 재 진입 시 필터 상태 유지

![SHANA K-042](https://github.com/user-attachments/assets/5c2c5be9-2a36-45a0-9175-50b34cfd85d8)
